### PR TITLE
Add Sanic minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanic_gzip",
-    version="0.3.0",
+    version="0.4.0",
     author="Damien Alexandre",
     author_email="damien.alexandre@muage.org",
     description="Add compress to Sanic response as decorator",
@@ -19,6 +19,6 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        'sanic'
+        'sanic>=21.12'
     ]
 )


### PR DESCRIPTION
Breaking changes in `sanic 21.12` make `sanic-gzip 0.4.0` incompatible with older `Sanic` releases